### PR TITLE
Add API key validation in ai_model

### DIFF
--- a/HackX/ai_model.py
+++ b/HackX/ai_model.py
@@ -7,6 +7,13 @@ from sklearn.metrics.pairwise import cosine_similarity
 # Loading the API key from the .env file
 load_dotenv()
 cohere_api_key = os.getenv("COHERE_API_KEY")
+
+if not cohere_api_key:
+    raise EnvironmentError(
+        "COHERE_API_KEY environment variable is missing or empty. "
+        "Please set your Cohere API key."
+    )
+
 co = cohere.Client(cohere_api_key)
 
 def calculate_similarity(text1, text2, scale=100):


### PR DESCRIPTION
## Summary
- detect missing `COHERE_API_KEY` in `ai_model`
- raise a clear exception when no API key is set

## Testing
- `python -m py_compile HackX/ai_model.py`
- `python -m py_compile HackX/app.py HackX/api.py HackX/rule_model.py`
- `pip install -r requirements.txt`
- `env -u COHERE_API_KEY python HackX/app.py` *(fails with missing key)*

------
https://chatgpt.com/codex/tasks/task_e_688cc393534c832a9ff35b2569f1786f