### PR TITLE
Add CSRF protection

### DIFF
--- a/HackX/app.py
+++ b/HackX/app.py
@@ -2,8 +2,10 @@ from flask import Flask, render_template, request, redirect, url_for, jsonify
 from rule_model import plagiarism_detection
 from ai_model import calculate_similarity, generate_feedback
 from api import api_bp
+from flask_wtf import CSRFProtect
 import urllib.parse
 import logging
+import os
 
 logging.basicConfig(
     level=logging.INFO,
@@ -13,7 +15,10 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
+app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'dev-secret-key')
+csrf = CSRFProtect(app)
 app.register_blueprint(api_bp)
+csrf.exempt(api_bp)
 
 @app.route('/')
 def index():

--- a/HackX/templates/get_started.html
+++ b/HackX/templates/get_started.html
@@ -27,6 +27,7 @@
     <!-- Main Section -->
     <section class="main-content">
         <form action="{{ url_for('get_started') }}" method="POST">
+            {{ csrf_token() }}
             <div class="left-section">
                 <!-- Code Area -->
                 <textarea name="code" placeholder="Code Area" rows="10"></textarea>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ Flask==3.1.0
 python-dotenv==1.0.1
 cohere==5.13.8
 scikit-learn==1.6.1
+Flask-WTF==1.2.2
 


### PR DESCRIPTION
## Summary
- secure forms using Flask-WTF
- configure secret key and register CSRF in app
- include CSRF token in `get_started.html`
- add dependency for Flask-WTF

## Testing
- `pip install -r requirements.txt`
- `pytest -q`